### PR TITLE
just exec mkdir -p without checking its existance

### DIFF
--- a/sakura_rentalserver/scripts/wp_backup.sh
+++ b/sakura_rentalserver/scripts/wp_backup.sh
@@ -6,9 +6,7 @@ BACKUP_DATE=$(date +"%Y%m%d")
 BACKUP_TIME=$(date +"%H%M%S")
 BACKUP_DATETIME="${BACKUP_DATE}_${BACKUP_TIME}"
 
-if [ ! -e "${BACKUP_DIR}" ]; then
-    mkdir -p ${BACKUP_DIR}
-fi
+mkdir -p ${BACKUP_DIR}
 
 cd ${BACKUP_DIR} || exit 1;
 


### PR DESCRIPTION
"mkdir -p dir" create dir if the dir directory is not exist. So "directory existeig check" is not needed.